### PR TITLE
added support for diskless creation of TLS key pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,88 @@ Use this library for testing purposes only, e.g. to experiment with the built-in
 
 # Usage
 
-
-    package main
+```go
+package main
     
-    import (
-        "fmt"
-        "github.com/kabukky/httpscerts"
-        "log"
-        "net/http"
-    )
+import (
+    "fmt"
+    "github.com/kabukky/httpscerts"
+    "log"
+    "net/http"
+)
     
-    func handler(w http.ResponseWriter, r *http.Request) {
-        fmt.Fprintf(w, "Hi there!")
-    }
+func handler(w http.ResponseWriter, r *http.Request) {
+    fmt.Fprintf(w, "Hi there!")
+}
     
-    func main() {
-        // Check if the cert files are available.
-        err := httpscerts.Check("cert.pem", "key.pem")
-        // If they are not available, generate new ones.
+func main() {
+    // Check if the cert files are available.
+    err := httpscerts.Check("cert.pem", "key.pem")
+    // If they are not available, generate new ones.
+    if err != nil {
+        err = httpscerts.Generate("cert.pem", "key.pem", "127.0.0.1:8081")
         if err != nil {
-            err = httpscerts.Generate("cert.pem", "key.pem", "127.0.0.1:8081")
-            if err != nil {
-                log.Fatal("Error: Couldn't create https certs.")
-            }
+            log.Fatal("Error: Couldn't create https certs.")
         }
-        http.HandleFunc("/", handler)
-        http.ListenAndServeTLS(":8081", "cert.pem", "key.pem", nil)
     }
+    http.HandleFunc("/", handler)
+    http.ListenAndServeTLS(":8081", "cert.pem", "key.pem", nil)
+}
+```
+
+# Alternative usage without disk access
+
+The method `httpscerts.GenerateArrays()` has been added to enable use cases where writing to disk is not desirable. If the initial check fails, a `tls.Certificate` is populated and passed to a `http.Server` instance.
+
+```go
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"github.com/kabukky/httpscerts"
+	"log"
+	"net/http"
+	"time"
+)
+
+func main() {
+	// Check if the cert files are available.
+	certFile := "cert.pem"
+	keyFile := "key.pem"
+	err := httpscerts.Check(certFile, keyFile)
+	// If they are not available, generate new ones.
+	if err != nil {
+		cert, key, err := httpscerts.GenerateArrays("127.0.0.1:8081")
+		if err != nil {
+			log.Fatal("Error: Couldn't create https certs.")
+		}
+
+		keyPair, err := tls.X509KeyPair(cert, key)
+		if err != nil {
+			log.Fatal("Error: Couldn't create key pair")
+		}
+
+		var certificates []tls.Certificate
+		certificates = append(certificates, keyPair)
+
+		cfg := &tls.Config{
+			MinVersion:               tls.VersionTLS12,
+			PreferServerCipherSuites: true,
+			Certificates:             certificates,
+		}
+
+		s := &http.Server{
+			Addr:           ":8081",
+			Handler:        http.DefaultServeMux,
+			ReadTimeout:    10 * time.Second,
+			WriteTimeout:   10 * time.Second,
+			MaxHeaderBytes: 1 << 20,
+			TLSConfig:      cfg,
+		}
+		log.Fatal(s.ListenAndServeTLS("", ""))
+	}
+
+	log.Fatal(http.ListenAndServeTLS(":8081", certFile, keyFile, nil))
+}
+```


### PR DESCRIPTION
With this change, httpscerts supports the generation and use of self-signed certificates without persisting them on disk. 